### PR TITLE
BUG. Env. Fix bug when setting step environment variables

### DIFF
--- a/lume/config/install_config.py
+++ b/lume/config/install_config.py
@@ -9,8 +9,8 @@ from lume.config.get_envs import get_envs
 class InstallConfig(BaseModel):
     run: List[str]
     cwd: Optional[str] = None
-    envs: Optional[Dict[str, str]] = None
-    overwrote_envs: Optional[List[str]] = None
+    envs: Dict[str, str] = dict()
+    overwrote_envs: List[str] = list()
 
     def add_shared_env(self, shared_envs: Dict[str, str]):
         if shared_envs and self.envs:

--- a/lume/config/step_config.py
+++ b/lume/config/step_config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -10,13 +10,13 @@ from lume.config.get_envs import get_envs
 class StepConfig(BaseModel):
     run: List[str]
     cwd: Optional[str] = None
-    envs: Optional[Dict[str, Any]] = None
+    envs: Dict[str, str] = dict()
     setup: Optional[List[str]] = None
     teardown: Optional[List[str]] = None
     setup_detach: Optional[Dict] = None
     wait_seconds: Optional[int] = None
     wait_http_200: Optional[str] = None
-    overwrote_envs: Optional[List[str]] = None
+    overwrote_envs: List[str] = list()
 
     def add_shared_env(self, shared_envs: Dict[str, str]):
         if shared_envs and self.envs:

--- a/lume/config/uninstall_config.py
+++ b/lume/config/uninstall_config.py
@@ -9,8 +9,8 @@ from lume.config.get_envs import get_envs
 class UninstallConfig(BaseModel):
     run: List[str]
     cwd: Optional[str] = None
-    envs: Optional[Dict[str, str]] = None
-    overwrote_envs: Optional[List[str]] = None
+    envs: Dict[str, str] = dict()
+    overwrote_envs: List[str] = list()
 
     def add_shared_env(self, shared_envs: Dict[str, str]):
         if shared_envs and self.envs:

--- a/lume/src/application/use_cases/env_manager.py
+++ b/lume/src/application/use_cases/env_manager.py
@@ -10,8 +10,6 @@ class EnvManager:
         self.logger = logger
 
     def set(self, envs: Dict[str, str]) -> None:
-        if not envs:
-            return
         self.logger.log(
             GLOBAL, f"{Colors.OKGREEN}Set Global Environment Variables{Colors.ENDC}"
         )
@@ -27,14 +25,10 @@ class EnvManager:
                 self.logger.log(ENVAR, f"env: set {envar}={value}")
 
     def unset(self, envs: Dict[str, str]) -> None:
-        if not envs:
-            return
         for envar in envs.keys():
             os.unsetenv(envar)
 
     def set_step(self, step):
-        if not step.envs:
-            return
         for envar, value in step.envs.items():
             env_original_value = os.environ.get(envar)
             os.environ[envar] = str(value)
@@ -53,7 +47,5 @@ class EnvManager:
                     self.logger.log(ENVAR, f"env: set {envar}={value}")
 
     def unset_step(self, step):
-        if not step.envs:
-            return
         for envar in step.envs.keys():
             os.unsetenv(envar)

--- a/lume/src/application/use_cases/lume_use_case.py
+++ b/lume/src/application/use_cases/lume_use_case.py
@@ -120,9 +120,6 @@ class LumeUseCase:
         else:
             step = self.config.steps.get(action)
 
-        if step is None or not hasattr(step, "envs") or not step.envs:
-            return
-
         self.env_manager.set_step(step)
 
     def _unset_env(self, action):
@@ -132,9 +129,6 @@ class LumeUseCase:
             step = self.config.uninstall
         else:
             step = self.config.steps.get(action)
-
-        if step is None or not (hasattr(step, "envs") and not step.envs):
-            return
 
         self.env_manager.unset_step(step)
 

--- a/lume/src/application/use_cases/lume_use_case.py
+++ b/lume/src/application/use_cases/lume_use_case.py
@@ -120,7 +120,7 @@ class LumeUseCase:
         else:
             step = self.config.steps.get(action)
 
-        if step is None or not (hasattr(step, "envs") and not step.envs):
+        if step is None or not hasattr(step, "envs") or not step.envs:
             return
 
         self.env_manager.set_step(step)

--- a/tests/src/test_lume_use_case.py
+++ b/tests/src/test_lume_use_case.py
@@ -1,13 +1,14 @@
 import pytest
 
 from lume.src.application.use_cases.lume_use_case import LumeUseCase
-from lume.src.domain.services.logger import HIGHLIGHT
+from lume.src.domain.services.logger import GLOBAL, HIGHLIGHT
 from lume.src.infrastructure.services.executor.fake_executor_service import (
     FakeExecutorService,
 )
 from lume.src.infrastructure.services.killer.fake_killer_service import (
     FakeKillerService,
 )
+from lume.src.infrastructure.services.logger.colors import Colors
 from lume.src.infrastructure.services.logger.fake_logger import FakeLogger
 from lume.src.infrastructure.services.setup.fake_setup_service import FakeSetupService
 from tests.src.mothers.config_mother import ConfigMother
@@ -38,5 +39,10 @@ def test_should_repr_as_expected_an_error_with_message(given_command):
     lume_use_case.execute([f"{given_command}"])
 
     first_logging_message = fake_logger.get_logging_messages()[0]
+    second_logging_message = fake_logger.get_logging_messages()[1]
 
-    assert first_logging_message == (HIGHLIGHT, f"Step: {given_command}")
+    assert first_logging_message == (
+        GLOBAL,
+        f"{Colors.OKGREEN}Set Global Environment Variables{Colors.ENDC}",
+    )
+    assert second_logging_message == (HIGHLIGHT, f"Step: {given_command}")


### PR DESCRIPTION
I notice that envs defined in steps are not setting in some cases ([see problem](https://github.com/alice-biometrics/clients/pull/25))

I tested it locally and seem is fullfill the second condition of below snippet when envs are present in a step
```python
if step is None or not (hasattr(step, "envs") and not step.envs):
    return
```